### PR TITLE
Inserção geral de tipagem de dados

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.analysis.typeCheckingMode": "strict"
+}

--- a/app/bot.py
+++ b/app/bot.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+from typing import Any
+
 from telethon import TelegramClient
 from app.plugin_loader import PluginLoader
 
@@ -11,13 +13,14 @@ class Client(TelegramClient):
     Custom Telegram Client with additional functionalities for managing handlers and lifecycle.
     """
 
-    def __init__(self, bot_token, plugins=None, **kwargs):
+    def __init__(self, bot_token: Any, plugins: Any | None=None, **kwargs: Any) -> None:
         """
         Initializes the Telegram client with a bot token.
 
         :param bot_token: The bot token to authenticate with the Telegram API.
         :param kwargs: Additional keyword arguments to pass to the TelegramClient constructor.
         """
+
         super().__init__(**kwargs)
         self.bot_token = bot_token
         self.plugins = plugins
@@ -25,7 +28,7 @@ class Client(TelegramClient):
             "id": 123456
         }
 
-    async def send_message(self, chat_id, message='', **kwargs):
+    async def send_message(self, chat_id: Any, message: str='', **kwargs: Any):
         """
         Sends a message to a specified chat.
 
@@ -34,14 +37,16 @@ class Client(TelegramClient):
         :param kwargs: Additional arguments to customize the message (e.g., buttons, parse_mode).
         :return: The result of the send_message operation.
         """
+
         return await super().send_message(chat_id, message, **kwargs)
 
-    async def keep_alive(self):
+    async def keep_alive(self) -> None:
         """
         Keeps the bot connected to the Telegram API.
 
         Periodically checks the connection status and attempts to reconnect if disconnected.
         """
+
         while True:
             try:
                 if not self.is_connected():
@@ -52,15 +57,16 @@ class Client(TelegramClient):
                 logging.error(f'Error in keep_alive: {e}', exc_info=True)
                 await asyncio.sleep(60)
 
-    async def run(self):
+    async def run(self) -> None:
         """
         Starts the bot, loads event handlers, and manages its lifecycle.
 
         Handles connection errors by attempting to reconnect automatically.
         """
+
         try:
             await self.start(bot_token=self.bot_token)
-            plugin_loader = PluginLoader(
+            plugin_loader: PluginLoader = PluginLoader(
                 self,
                 self.plugins
             )
@@ -75,22 +81,25 @@ class Client(TelegramClient):
             await asyncio.sleep(5)
             await self.run()
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
         """
         Gracefully disconnects the bot from the Telegram API.
 
         Ensures proper cleanup of resources before exiting.
         """
+
         await self.disconnect()
         logging.info('Bot successfully disconnected.')
 
-    def start_service(self):
+    def start_service(self) -> None:
         """
         Starts the bot service and runs it until interrupted.
 
         Handles cleanup upon keyboard interruption to ensure a graceful shutdown.
         """
-        loop = asyncio.get_event_loop()
+
+        loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+
         try:
             loop.run_until_complete(self.run())
         except KeyboardInterrupt:

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+from typing import Final, Any
 import sys
 
 if sys.version_info >= (3, 11):
@@ -6,7 +7,7 @@ else:
     import toml
 
 
-def load_config(file_path):
+def load_config(file_path: str) -> dict[str, Any]:
     if sys.version_info >= (3, 11):
         with open(file_path, 'rb') as f:
             return tomllib.load(f)
@@ -16,12 +17,12 @@ def load_config(file_path):
 
 config = load_config('config.toml')
 
-API_ID = config['API']['ID']
-API_HASH = config['API']['HASH']
-BOT_TOKEN = config['API']['BOT_TOKEN']
-ADMIN_IDS = config['ADMIN']['IDS']
-APP_NAME = config['APPLICATION']['APP_NAME']
-APP_AUTHOR = config['APPLICATION']['APP_AUTHOR']
-APP_VERSION = config['APPLICATION']['APP_VERSION']
-DEVICE_MODEL = config['APPLICATION']['DEVICE_MODEL']
-SYSTEM_VERSION = config['APPLICATION']['SYSTEM_VERSION']
+API_ID: Final[str] = config['API']['ID']
+API_HASH: Final[str] = config['API']['HASH']
+BOT_TOKEN: Final[str] = config['API']['BOT_TOKEN']
+ADMIN_IDS: Final[str] = config['ADMIN']['IDS']
+APP_NAME: Final[str] = config['APPLICATION']['APP_NAME']
+APP_AUTHOR: Final[str] = config['APPLICATION']['APP_AUTHOR']
+APP_VERSION: Final[str] = config['APPLICATION']['APP_VERSION']
+DEVICE_MODEL: Final[str] = config['APPLICATION']['DEVICE_MODEL']
+SYSTEM_VERSION: Final[str] = config['APPLICATION']['SYSTEM_VERSION']

--- a/app/handlers/callbacks.py
+++ b/app/handlers/callbacks.py
@@ -1,8 +1,8 @@
 import logging
-from telethon import (
-    events
-)
+from telethon import events
+from typing import Any
 from app.utils.base_handler import ClientHandler
+
 
 logging.basicConfig(level=logging.INFO)
 
@@ -10,7 +10,7 @@ client = ClientHandler()
 
 
 @client.on(events.CallbackQuery)
-async def handle_callback(event):
+async def handle_callback(event: Any):
     """
     Handles callback queries triggered by inline button interactions.
 

--- a/app/handlers/commands.py
+++ b/app/handlers/commands.py
@@ -1,8 +1,6 @@
 import logging
-from telethon import (
-    events,
-    Button,
-)
+from typing import Any
+from telethon import events, Button
 from app.utils.base_handler import ClientHandler
 
 logging.basicConfig(level=logging.INFO)
@@ -11,7 +9,7 @@ client = ClientHandler()
 
 
 @client.on(events.NewMessage(pattern='/start'))
-async def handle_start(event):
+async def handle_start(event: Any):
     """
     Handles the `/start` command by sending a greeting message.
 
@@ -36,7 +34,7 @@ async def handle_start(event):
     )
 
 @client.on(events.NewMessage(pattern='/button'))
-async def handle_send_button(event):
+async def handle_send_button(event: Any):
     """
     Handles the `/button` command by sending a message with an inline button.
 

--- a/app/paths.py
+++ b/app/paths.py
@@ -1,17 +1,18 @@
+from typing import Final
 import os
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-BASE_NAME = os.path.basename(BASE_DIR)
-HANDLER_DIR = os.path.join(BASE_NAME, 'handlers')
-SESSIONS_DIR = os.path.join(BASE_DIR, 'sessions')
-CLIENTS_DIR = os.path.join(SESSIONS_DIR, 'clients')
+BASE_DIR: Final[str] = os.path.dirname(os.path.abspath(__file__))
+BASE_NAME: Final[str] = os.path.basename(BASE_DIR)
+HANDLER_DIR: Final[str] = os.path.join(BASE_NAME, 'handlers')
+SESSIONS_DIR: Final[str] = os.path.join(BASE_DIR, 'sessions')
+CLIENTS_DIR: Final[str] = os.path.join(SESSIONS_DIR, 'clients')
 
 
-def get_session_path(client_id):
+def get_session_path(client_id: int) -> str:
     return os.path.join(CLIENTS_DIR, f'{client_id}')
 
 
-def get_handlers_path(plugins_dir=None):
+def get_handlers_path(plugins_dir: str | None=None) -> str:
     if plugins_dir:
         return ".".join(os.path.join(BASE_NAME, plugins_dir).split(os.path.sep))
 

--- a/app/plugins/commands/start.py
+++ b/app/plugins/commands/start.py
@@ -1,8 +1,8 @@
 import logging
-from telethon import (
-    events
-)
+from typing import Any
+from telethon import events
 from app.utils.base_handler import ClientHandler
+
 
 logging.basicConfig(level=logging.INFO)
 
@@ -10,12 +10,13 @@ client = ClientHandler()
 
 
 @client.on(events.NewMessage(pattern='/start'))
-async def handle_start(event):
+async def handle_start(event: Any):
     """
     Handles the `/start` command by sending a greeting message.
 
     :param event: The event triggered by the `/start` command.
     """
+
     sender = await event.get_sender()
     sender_id = sender.id
     logging.info(f"Start Handler Triggered by User ID: {sender_id}")
@@ -36,12 +37,13 @@ async def handle_start(event):
 
 
 @client.on(events.NewMessage(pattern='/help'))
-async def handle_help(event):
+async def handle_help(event: Any):
     """
     Handles the `/help` command by sending a greeting message.
 
     :param event: The event triggered by the `/help` command.
     """
+
     sender = await event.get_sender()
     sender_id = sender.id
     logging.info(f"Help Handler Triggered by User ID: {sender_id}")
@@ -62,7 +64,7 @@ async def handle_help(event):
 
 
 @client.on(events.NewMessage(pattern='/exit'))
-async def handle_exit(event):
+async def handle_exit(event: Any):
     """
     Handles the `/exit` command by sending a greeting message.
 

--- a/app/plugins/message.py
+++ b/app/plugins/message.py
@@ -1,21 +1,22 @@
 import logging
-from telethon import (
-    events
-)
+from typing import Any
+from telethon import events
 from app.utils.base_handler import ClientHandler
+
 
 logging.basicConfig(level=logging.INFO)
 
-client = ClientHandler()
+client: ClientHandler = ClientHandler()
 
 
 @client.on(events.NewMessage(pattern='/text'))
-async def handle_text(event):
+async def handle_text(event: Any) -> None:
     """
     Handles the `/text` command by sending a greeting message.
 
     :param event: The event triggered by the `/text` command.
     """
+
     sender = await event.get_sender()
     sender_id = sender.id
     logging.info(f"Start Handler Triggered by User ID: {sender_id}")

--- a/app/utils/base_handler.py
+++ b/app/utils/base_handler.py
@@ -1,17 +1,18 @@
-from typing import Callable
+from typing import Callable, Any
 
 class ClientHandler:
     """
     Decorator to register events on the Telegram client.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initializes the handler decorator.
         """
+
         self.event = None
 
-    def on(self, event):
+    def on(self, event: Any) -> Callable:
         """
         Initializes the handler decorator with a specific event.
 
@@ -34,12 +35,13 @@ class ClientHandler:
 
         return decorator
 
-    def __call__(self, func: Callable):
+    def __call__(self, func: Callable) -> Callable:
         """
         Marks the function as a handler directly using the stored event.
 
         :param func: The function to be decorated as an event handler.
         :return: The decorated function with handler metadata.
         """
+
         return self.on(self.event)(func)
 

--- a/main.py
+++ b/main.py
@@ -12,12 +12,12 @@ from app.config import (
     API_HASH,
 )
 
-SESSION_PATH = os.path.join(
+SESSION_PATH: str = os.path.join(
     SESSIONS_DIR,
     APP_NAME
 )
 
-plugins = dict(
+plugins: dict[str, str | list[str]] = dict(
     root="plugins",
     include=[
         "commands.start handle_exit handle_start handle_help", "message"
@@ -27,7 +27,7 @@ plugins = dict(
 
 # plugins = dict(root="plugins")
 
-client = Client(
+client: Client = Client(
     bot_token=BOT_TOKEN,
     session=SESSION_PATH,
     api_id=API_ID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "smartbot"
 version = "0.1.0"
 description = "Um boilerplate para bots com suporte a modularização e plugins inteligentes, inspirado nos smart plugins do Pyrogram."
 authors = [
-    {name = "cleiton",email = "cleiton.leonel@gmail.com"}
+    {name = "cleiton", email = "cleiton.leonel@gmail.com"}
 ]
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
Adição/inserção de tipos de dados globalmente em funções e variáveis.

Foram inseridas em variáveis, constantes, argumentos e retornos de funções os tipos de dados que - aparentemente - melhor se encaixavam, seguindo em alguns casos a própria atribuição de valor ou docstrings (que diga-se de passagem, seguem padrões diferentes em arquivos diferentes).

Três coisas eu recomendo, caso considere aceitar este PR:
1. Utilizar um linter e checker Python (recomendação particular: [`ruff`](https://docs.astral.sh/ruff)
2. Revisar os dados anotados como `typing.Any` - a tipagem foi utilizada em situações onde não pude capturar o contexto com precisão
3. Definir o Poetry como padrão, removendo o `requirements.txt` e concentrando as dependências (core e dev) no `pyproject.toml` - isso assegurará e forçará o padrão de desenvolvimento que você mesmo recomenda utilizar

Caso seja de bom grado (e agrado) utilizar o Ruff, há um modelo interessante para acrescentar no `pyproject.toml`:

```toml
[tool.ruff]
line-length = 88
exclude = [".env", ".venv"]
fix = true

[tool.ruff.format]
quote-style = "single"
docstring-code-format = true

[tool.ruff.lint]
select = ["I", "E", "UP", "F"]
fixable = ["ALL"]

[tool.ruff.lint.isort]
case-sensitive = true
lines-after-imports = 2
```

Com isso executar `ruff format` seguido de `ruff check` resolverá pequenas issues de padronização - vide documentação para uso da ferramenta e edição dos parâmetros.

Vim através do TabNews.